### PR TITLE
Make languages map public

### DIFF
--- a/example/lib/example.g.dart
+++ b/example/lib/example.g.dart
@@ -4,7 +4,7 @@ import 'package:flutter/widgets.dart';
 class AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
   @override
   bool isSupported(Locale locale) =>
-      AppLocalizations._languages.containsKey(locale.languageCode);
+      AppLocalizations.languages.containsKey(locale);
   @override
   Future<AppLocalizations> load(Locale locale) =>
       SynchronousFuture<AppLocalizations>(AppLocalizations(locale));
@@ -13,11 +13,11 @@ class AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
 }
 
 class AppLocalizations {
-  AppLocalizations(this.locale) : this.labels = _languages[locale];
+  AppLocalizations(this.locale) : this.labels = languages[locale];
 
   final Locale locale;
 
-  static final Map<Locale, AppLocalizations_Labels> _languages = {
+  static final Map<Locale, AppLocalizations_Labels> languages = {
     Locale.fromSubtags(languageCode: "fr"): AppLocalizations_Labels(
       dates: AppLocalizations_Labels_Dates(
         weekday: AppLocalizations_Labels_Dates_Weekday(

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -36,7 +36,7 @@ class DartBuilder {
       ..lambda = true
       ..annotations.add(CodeExpression(Code("override")))
       ..body = Code(
-          "${localizations.name}._languages.containsKey(locale)")
+          "${localizations.name}.languages.containsKey(locale)")
       ..requiredParameters.add(Parameter((b) => b
         ..name = "locale"
         ..type = refer("Locale")))));
@@ -80,10 +80,10 @@ class DartBuilder {
       ..toThis = true));
 
     constructor.initializers
-        .add(Code("this.labels = _languages[locale]"));
+        .add(Code("this.labels = languages[locale]"));
 
     result.fields.add(Field((b) => b
-      ..name = "_languages"
+      ..name = "languages"
       ..static = true
       ..assignment = _createLanguageMap(localizations)
       ..modifier = FieldModifier.final$

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_csv_localization
 description: Flutter localizations generator from CSV files.
-version: 0.3.0+1
+version: 0.3.1
 homepage: https://github.com/aloisdeniel/flutter_csv_localization
 author: Aloïs Deniel <alois.deniel@outlook.com>
 


### PR DESCRIPTION
It is very good to use keys of languages map as supportedLocales array for MaterialApp.
`
 MaterialApp(
      ...
      supportedLocales: AppLocalizations.languages.keys,
    );
`
Thus, it is not necessary to manually change this array.